### PR TITLE
Use pure-Ruby gems instead of Raptor

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -29,7 +29,9 @@ GEMSPEC = Gem::Specification.new do |gem|
   gem.requirements               = []
   gem.add_runtime_dependency     'rdf-trix',       '~> 0.2.0'
   gem.add_runtime_dependency     'rdf-json',       '~> 0.2.0'
-  gem.add_runtime_dependency     'rdf-raptor',     '~> 0.4.0'
+  gem.add_runtime_dependency     'rdf-n3',         '~> 0.2.0'
+  gem.add_runtime_dependency     'rdf-rdfa',       '~> 0.2.0'
+  gem.add_runtime_dependency     'rdf-rdfxml',     '~> 0.2.0'
   gem.add_runtime_dependency     'rdf-isomorphic', '>= 0.2.0'
   gem.add_runtime_dependency     'rdf',            '~> 0.2.3'
   gem.add_development_dependency 'yard',           '>= 0.5.8'

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Features
 --------
 
 * Includes [N-Triples][] support using [RDF.rb][].
-* Includes [RDF/XML][], [Turtle][] and [RDFa][] support using the
-  [RDF::Raptor][] gem.
-* Includes [RDF/JSON][] support using the [RDF::JSON][] gem.
+* Includes [RDF/XML][] support using the [RDF::RDFXML][] gem.
+* Includes [Turtle][] and [Notation3][] support using the [RDF::N3][] gem.
+* Includes [RDFa][] support using the [RDF::RDFa][] gem.
 * Includes [TriX][] support using the [RDF::TriX][] gem.
 * Maintains release parity with RDF.rb.
 * Specifies all gem dependencies in a [production-safe][versioning] manner.
@@ -35,7 +35,9 @@ Dependencies
 
 * [RDF.rb](http://rubygems.org/gems/rdf) (>= 0.2.3)
 * [RDF::Isomorphic](http://rubygems.org/gems/rdf-isomorphic) (>= 0.2.0)
-* [RDF::Raptor](http://rubygems.org/gems/rdf-raptor) (>= 0.4.0)
+* [RDF::N3](http://rubygems.org/gems/rdf-n3) (>= 0.2.0)
+* [RDF::RDFa](http://rubygems.org/gems/rdf-rdfa) (>= 0.2.0)
+* [RDF::RDFXML](http://rubygems.org/gems/rdf-rdfxml) (>= 0.2.0)
 * [RDF::JSON](http://rubygems.org/gems/rdf-json) (>= 0.2.0)
 * [RDF::TriX](http://rubygems.org/gems/rdf-trix) (>= 0.2.0)
 
@@ -54,13 +56,16 @@ This is free and unencumbered public domain software. For more
 information, see <http://unlicense.org/> or the accompanying UNLICENSE file.
 
 [RDF.rb]:         http://rdf.rubyforge.org/
-[RDF::Raptor]:    http://rdf.rubyforge.org/raptor/
+[RDF::N3]:        http://rdoc.info/github/gkellogg/rdf-n3
+[RDF::RDFa]:      http://rdoc.info/github/gkellogg/rdf-rdfa
+[RDF::RDFXML]:    http://rdoc.info/github/gkellogg/rdf-rdfxml
 [RDF::JSON]:      http://rdf.rubyforge.org/json/
 [RDF::TriX]:      http://rdf.rubyforge.org/trix/
 [SPARQL::Client]: http://sparql.rubyforge.org/client/
 [Linked Data]:    http://linkeddata.org/
 [N-Triples]:      http://en.wikipedia.org/wiki/N-Triples
 [Turtle]:         http://en.wikipedia.org/wiki/Turtle_(syntax)
+[Notation3]:      http://en.wikipedia.org/wiki/Notation3
 [RDF/XML]:        http://en.wikipedia.org/wiki/RDF/XML
 [RDF/JSON]:       http://n2.talis.com/wiki/RDF_JSON_Specification
 [TriX]:           http://www.w3.org/2004/03/trix/

--- a/lib/linkeddata.rb
+++ b/lib/linkeddata.rb
@@ -7,8 +7,14 @@ module LinkedData
   # @see http://rubygems.org/gems/rdf-isomorphic
   require 'rdf/isomorphic'
 
-  # @see http://rubygems.org/gems/rdf-raptor
-  require 'rdf/raptor'
+  # @see http://rubygems.org/gems/rdf-n3
+  require 'rdf/n3'
+
+  # @see http://rubygems.org/gems/rdf-rdfa
+  require 'rdf/rdfa'
+
+  # @see http://rubygems.org/gems/rdf-rdfxml
+  require 'rdf/rdfxml'
 
   # @see http://rubygems.org/gems/rdf-json
   require 'rdf/json'


### PR DESCRIPTION
I believe you discussed doing this already. Note that the dependencies should be updated to 0.3.0 for most everything when appropriate.
