### PR TITLE
Require Ruby >= 1.9.3

### DIFF
--- a/linkeddata.gemspec
+++ b/linkeddata.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.test_files         = %w()
   gem.has_rdoc           = false
 
-  gem.required_ruby_version      = '>= 2.0'
+  gem.required_ruby_version      = '>= 1.9.3'
   gem.requirements               = []
   gem.add_runtime_dependency     'rdf',            '~> 1.1', '>= 1.1.11'
   gem.add_runtime_dependency     'rdf-aggregate-repo', '~> 1.1'


### PR DESCRIPTION
With https://github.com/ruby-rdf/rdf-tabular/pull/1, linkeddata should also be able to support Ruby 1.9.
